### PR TITLE
Consistent typing for enums

### DIFF
--- a/golem-base-indexer/golem-base-indexer-proto/proto/v1/golem-base-indexer.proto
+++ b/golem-base-indexer/golem-base-indexer-proto/proto/v1/golem-base-indexer.proto
@@ -79,9 +79,9 @@ message CountOperationsResponse {
 }
 
 enum EntityStatus {
-  Active = 0;
-  Deleted = 1;
-  Expired = 2;
+  ACTIVE = 0;
+  DELETED = 1;
+  EXPIRED = 2;
 }
 
 message Entity {

--- a/golem-base-indexer/golem-base-indexer-proto/swagger/v1/golem-base-indexer.swagger.yaml
+++ b/golem-base-indexer/golem-base-indexer-proto/swagger/v1/golem-base-indexer.swagger.yaml
@@ -313,10 +313,10 @@ definitions:
   v1EntityStatus:
     type: string
     enum:
-      - Active
-      - Deleted
-      - Expired
-    default: Active
+      - ACTIVE
+      - DELETED
+      - EXPIRED
+    default: ACTIVE
   v1FullEntity:
     type: object
     properties:

--- a/golem-base-indexer/types/package.json
+++ b/golem-base-indexer/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@golembase/l3-indexer-types",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "TypeScript definitions for Golem Base Indexer microservice",
   "main": "./dist/golem-base-indexer-proto/proto/v1/golem-base-indexer.js",
   "types": "./dist/golem-base-indexer-proto/proto/v1/golem-base-indexer.d.ts",


### PR DESCRIPTION
Right now we have operation type as uppercase and entity status as pascal case. Lets fix this.