### PR TITLE
Rename `block` to `block_number` for clarity

### DIFF
--- a/golem-base-indexer/golem-base-indexer-proto/proto/v1/api_config_http.yaml
+++ b/golem-base-indexer/golem-base-indexer-proto/proto/v1/api_config_http.yaml
@@ -31,7 +31,7 @@ http:
       get: /api/v1/leaderboard/biggest-spenders
 
     - selector: blockscout.golemBaseIndexer.v1.GolemBaseIndexerService.BlockStats
-      get: /api/v1/block/{block}/stats
+      get: /api/v1/block/{block_number}/stats
 
     #################### Health ####################
 

--- a/golem-base-indexer/golem-base-indexer-proto/proto/v1/golem-base-indexer.proto
+++ b/golem-base-indexer/golem-base-indexer-proto/proto/v1/golem-base-indexer.proto
@@ -231,7 +231,7 @@ message BiggestSpender {
 }
 
 message BlockStatsRequest {
-  string block = 1;
+  string block_number = 1;
 }
 
 message BlockStatsResponse {

--- a/golem-base-indexer/golem-base-indexer-proto/swagger/v1/golem-base-indexer.swagger.yaml
+++ b/golem-base-indexer/golem-base-indexer-proto/swagger/v1/golem-base-indexer.swagger.yaml
@@ -29,7 +29,7 @@ paths:
           type: string
       tags:
         - GolemBaseIndexerService
-  /api/v1/block/{block}/stats:
+  /api/v1/block/{block_number}/stats:
     get:
       operationId: GolemBaseIndexerService_BlockStats
       responses:
@@ -42,7 +42,7 @@ paths:
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: block
+        - name: block_number
           in: path
           required: true
           type: string

--- a/golem-base-indexer/golem-base-indexer-server/src/services/golem_base_indexer.rs
+++ b/golem-base-indexer/golem-base-indexer-server/src/services/golem_base_indexer.rs
@@ -269,13 +269,13 @@ impl GolemBaseIndexer for GolemBaseIndexerService {
         &self,
         request: Request<BlockStatsRequest>,
     ) -> Result<Response<BlockStatsResponse>, Status> {
-        let BlockStatsRequest { block } = request.into_inner();
-        let block = block.parse().map_err(|err| {
+        let BlockStatsRequest { block_number } = request.into_inner();
+        let block_number = block_number.parse().map_err(|err| {
             tracing::error!(?err, "invalid block number");
             Status::invalid_argument("invalid block number")
         })?;
 
-        let counts = repository::block::count_entities(&*self.db, block)
+        let counts = repository::block::count_entities(&*self.db, block_number)
             .await
             .map_err(|err| {
                 tracing::error!(?err, "failed to query block stats");

--- a/golem-base-indexer/types/package.json
+++ b/golem-base-indexer/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@golembase/l3-indexer-types",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "TypeScript definitions for Golem Base Indexer microservice",
   "main": "./dist/golem-base-indexer-proto/proto/v1/golem-base-indexer.js",
   "types": "./dist/golem-base-indexer-proto/proto/v1/golem-base-indexer.d.ts",


### PR DESCRIPTION
Renames the ambiguous `block` variable/parameter to `block_number` to make it more explicit that it refers to a block number rather than a block object or other block-related data. 
This improves code readability and reduces potential confusion for developers working with the codebase.