### PR TITLE
GBBE-205 - Block view - Storage metrics - Backend

### DIFF
--- a/golem-base-indexer/golem-base-indexer-logic/src/repository/block.rs
+++ b/golem-base-indexer/golem-base-indexer-logic/src/repository/block.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use sea_orm::{prelude::*, DbBackend, FromQueryResult, Statement};
 use tracing::instrument;
 
-use crate::types::{BlockEntitiesCount, BlockNumber};
+use crate::types::{BlockEntitiesCount, BlockNumber, BlockStorageUsage};
 
 use super::sql;
 
@@ -29,12 +29,29 @@ impl TryFrom<DbBlockEntitiesCount> for BlockEntitiesCount {
     }
 }
 
+#[derive(Debug, FromQueryResult)]
+struct DbBlockStorageUsage {
+    pub block_bytes: i64,
+    pub total_bytes: i64,
+}
+
+impl TryFrom<DbBlockStorageUsage> for BlockStorageUsage {
+    type Error = anyhow::Error;
+
+    fn try_from(value: DbBlockStorageUsage) -> Result<Self> {
+        Ok(Self {
+            block_bytes: value.block_bytes.try_into()?,
+            total_bytes: value.total_bytes.try_into()?,
+        })
+    }
+}
+
 #[instrument(skip(db))]
 pub async fn count_entities<T: ConnectionTrait>(
     db: &T,
     block_number: BlockNumber,
 ) -> Result<BlockEntitiesCount> {
-    let res = DbBlockEntitiesCount::find_by_statement(Statement::from_sql_and_values(
+    DbBlockEntitiesCount::find_by_statement(Statement::from_sql_and_values(
         DbBackend::Postgres,
         sql::COUNT_ENTITIES_BY_BLOCK,
         [block_number.into()],
@@ -42,8 +59,23 @@ pub async fn count_entities<T: ConnectionTrait>(
     .one(db)
     .await
     .context("Failed to count entities by block")?
-    .expect("Count will always return a row")
-    .try_into()?;
+    .expect("Entity counts will always return a row")
+    .try_into()
+}
 
-    Ok(res)
+#[instrument(skip(db))]
+pub async fn storage_usage<T: ConnectionTrait>(
+    db: &T,
+    block_number: BlockNumber,
+) -> Result<BlockStorageUsage> {
+    DbBlockStorageUsage::find_by_statement(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        sql::STORAGE_USAGE_BY_BLOCK,
+        [block_number.into()],
+    ))
+    .one(db)
+    .await
+    .context("Failed to get storage usage by block")?
+    .expect("Storage usage will always return a row")
+    .try_into()
 }

--- a/golem-base-indexer/golem-base-indexer-logic/src/repository/sql.rs
+++ b/golem-base-indexer/golem-base-indexer-logic/src/repository/sql.rs
@@ -173,3 +173,39 @@ SELECT
 FROM golem_base_entity_history
 WHERE block_number = $1
 "#;
+
+pub const STORAGE_USAGE_BY_BLOCK: &str = r#"
+WITH latest_entities_per_block AS (
+  SELECT
+    block_number,
+    data,
+    status,
+    entity_key,
+    ROW_NUMBER() OVER (PARTITION BY entity_key ORDER BY block_number DESC) as rn
+  FROM golem_base_entity_history
+  WHERE block_number <= $1
+),
+current_state AS (
+  SELECT
+    block_number,
+    data,
+    status,
+    entity_key
+  FROM latest_entities_per_block
+  WHERE rn = 1 AND status = 'active'
+),
+block_metrics AS (
+  SELECT
+    $1 as block_number,
+    -- Storage added in this specific block
+    COALESCE(SUM(CASE WHEN block_number = $1 THEN LENGTH(data) END), 0) as block_bytes,
+    -- Total storage up to and including this block
+    COALESCE(SUM(LENGTH(data)), 0) as total_bytes
+  FROM current_state
+)
+SELECT
+  block_number,
+  block_bytes,
+  total_bytes
+FROM block_metrics;
+"#;

--- a/golem-base-indexer/golem-base-indexer-logic/src/repository/sql.rs
+++ b/golem-base-indexer/golem-base-indexer-logic/src/repository/sql.rs
@@ -236,19 +236,12 @@ current_state AS (
     entity_key
   FROM latest_entities_per_block
   WHERE rn = 1 AND status = 'active'
-),
-block_metrics AS (
-  SELECT
-    $1 as block_number,
-    -- Storage added in this specific block
-    COALESCE(SUM(CASE WHEN block_number = $1 THEN LENGTH(data) END), 0) as block_bytes,
-    -- Total storage up to and including this block
-    COALESCE(SUM(LENGTH(data)), 0) as total_bytes
-  FROM current_state
 )
 SELECT
-  block_number,
-  block_bytes,
-  total_bytes
-FROM block_metrics;
+  $1 as block_number,
+  -- Storage added in this specific block
+  COALESCE(SUM(CASE WHEN block_number = $1 THEN LENGTH(data) END), 0) as block_bytes,
+  -- Total storage up to and including this block
+  COALESCE(SUM(LENGTH(data)), 0) as total_bytes
+FROM current_state
 "#;

--- a/golem-base-indexer/golem-base-indexer-logic/src/types.rs
+++ b/golem-base-indexer/golem-base-indexer-logic/src/types.rs
@@ -302,3 +302,9 @@ pub struct BlockEntitiesCount {
     pub delete_count: u64,
     pub extend_count: u64,
 }
+
+#[derive(Debug, Clone)]
+pub struct BlockStorageUsage {
+    pub block_bytes: u64,
+    pub total_bytes: u64,
+}

--- a/golem-base-indexer/golem-base-indexer-proto/proto/v1/golem-base-indexer.proto
+++ b/golem-base-indexer/golem-base-indexer-proto/proto/v1/golem-base-indexer.proto
@@ -235,9 +235,19 @@ message BlockStatsRequest {
 }
 
 message BlockStatsResponse {
+  BlockStatsCounts counts = 1;
+  BlockStatsStorage storage = 2;
+}
+
+message BlockStatsCounts {
   uint64 create_count = 1;
   uint64 update_count = 2;
   uint64 expire_count = 3;
   uint64 delete_count = 4;
   uint64 extend_count = 5;
+}
+
+message BlockStatsStorage {
+  uint64 block_bytes = 1;
+  uint64 total_bytes = 2;
 }

--- a/golem-base-indexer/golem-base-indexer-proto/src/lib.rs
+++ b/golem-base-indexer/golem-base-indexer-proto/src/lib.rs
@@ -4,10 +4,10 @@ use const_hex::traits::ToHexExt;
 
 use anyhow::{anyhow, Result};
 use golem_base_indexer_logic::types::{
-    BiggestSpenders, BlockEntitiesCount, EntitiesFilter, Entity, EntityHistoryEntry,
-    EntityHistoryFilter, EntityStatus, FullEntity, ListEntitiesFilter, ListOperationsFilter,
-    NumericAnnotation, OperationData, OperationFilter, OperationView, OperationsCount,
-    OperationsFilter, PaginationMetadata, PaginationParams, StringAnnotation,
+    BiggestSpenders, BlockEntitiesCount, BlockStorageUsage, EntitiesFilter, Entity,
+    EntityHistoryEntry, EntityHistoryFilter, EntityStatus, FullEntity, ListEntitiesFilter,
+    ListOperationsFilter, NumericAnnotation, OperationData, OperationFilter, OperationView,
+    OperationsCount, OperationsFilter, PaginationMetadata, PaginationParams, StringAnnotation,
 };
 
 pub mod blockscout {
@@ -445,7 +445,7 @@ impl From<BiggestSpenders> for v1::BiggestSpender {
     }
 }
 
-impl From<BlockEntitiesCount> for v1::BlockStatsResponse {
+impl From<BlockEntitiesCount> for v1::BlockStatsCounts {
     fn from(value: BlockEntitiesCount) -> Self {
         Self {
             create_count: value.create_count,
@@ -453,6 +453,15 @@ impl From<BlockEntitiesCount> for v1::BlockStatsResponse {
             expire_count: value.expire_count,
             delete_count: value.delete_count,
             extend_count: value.extend_count,
+        }
+    }
+}
+
+impl From<BlockStorageUsage> for v1::BlockStatsStorage {
+    fn from(value: BlockStorageUsage) -> Self {
+        Self {
+            block_bytes: value.block_bytes,
+            total_bytes: value.total_bytes,
         }
     }
 }

--- a/golem-base-indexer/golem-base-indexer-proto/swagger/v1/golem-base-indexer.swagger.yaml
+++ b/golem-base-indexer/golem-base-indexer-proto/swagger/v1/golem-base-indexer.swagger.yaml
@@ -398,7 +398,7 @@ definitions:
         type: string
       total_fees:
         type: string
-  v1BlockStatsResponse:
+  v1BlockStatsCounts:
     type: object
     properties:
       create_count:
@@ -414,6 +414,22 @@ definitions:
         type: string
         format: uint64
       extend_count:
+        type: string
+        format: uint64
+  v1BlockStatsResponse:
+    type: object
+    properties:
+      counts:
+        $ref: '#/definitions/v1BlockStatsCounts'
+      storage:
+        $ref: '#/definitions/v1BlockStatsStorage'
+  v1BlockStatsStorage:
+    type: object
+    properties:
+      block_bytes:
+        type: string
+        format: uint64
+      total_bytes:
         type: string
         format: uint64
   v1CountEntitiesResponse:

--- a/golem-base-indexer/golem-base-indexer-server/src/services/golem_base_indexer.rs
+++ b/golem-base-indexer/golem-base-indexer-server/src/services/golem_base_indexer.rs
@@ -275,13 +275,25 @@ impl GolemBaseIndexer for GolemBaseIndexerService {
             Status::invalid_argument("invalid block number")
         })?;
 
+        // Get entity counts
         let counts = repository::block::count_entities(&*self.db, block_number)
             .await
             .map_err(|err| {
-                tracing::error!(?err, "failed to query block stats");
-                Status::internal("failed to query block stats")
+                tracing::error!(?err, "failed to query block stats counts");
+                Status::internal("failed to query block stats counts")
             })?;
 
-        Ok(Response::new(counts.into()))
+        // Get storage usage
+        let storage = repository::block::storage_usage(&*self.db, block_number)
+            .await
+            .map_err(|err| {
+                tracing::error!(?err, "failed to query block storage usage");
+                Status::internal("failed to query block storage usage")
+            })?;
+
+        Ok(Response::new(BlockStatsResponse {
+            counts: Some(counts.into()),
+            storage: Some(storage.into()),
+        }))
     }
 }

--- a/golem-base-indexer/golem-base-indexer-server/tests/block_stats.rs
+++ b/golem-base-indexer/golem-base-indexer-server/tests/block_stats.rs
@@ -20,89 +20,153 @@ async fn block_stats_should_work() {
 
     // Test block 1
     let response: Value = test_server::send_get_request(&base, "/api/v1/block/1/stats").await;
-    let expected: Value = json!({
+    let counts: Value = json!({
         "create_count": "0",
         "update_count": "0",
         "expire_count": "0",
         "delete_count": "0",
         "extend_count": "0",
     });
+    let storage: Value = json!({
+        "block_bytes": "0",
+        "total_bytes": "0",
+    });
+    let expected = json!({
+        "counts": counts,
+        "storage": storage,
+    });
     assert_eq!(response, expected);
 
     // Test block 2
     let response: Value = test_server::send_get_request(&base, "/api/v1/block/2/stats").await;
-    let expected: Value = json!({
+    let counts: Value = json!({
         "create_count": "1",
         "update_count": "0",
         "expire_count": "0",
         "delete_count": "0",
         "extend_count": "0",
+    });
+    let storage: Value = json!({
+        "block_bytes": "25",
+        "total_bytes": "25",
+    });
+    let expected = json!({
+        "counts": counts,
+        "storage": storage,
     });
     assert_eq!(response, expected);
 
     // Test block 3
     let response: Value = test_server::send_get_request(&base, "/api/v1/block/3/stats").await;
-    let expected: Value = json!({
+    let counts: Value = json!({
         "create_count": "1",
         "update_count": "0",
         "expire_count": "0",
         "delete_count": "0",
         "extend_count": "0",
+    });
+    let storage: Value = json!({
+        "block_bytes": "25",
+        "total_bytes": "50",
+    });
+    let expected = json!({
+        "counts": counts,
+        "storage": storage,
     });
     assert_eq!(response, expected);
 
     // Test block 4
     let response: Value = test_server::send_get_request(&base, "/api/v1/block/4/stats").await;
-    let expected: Value = json!({
+    let counts: Value = json!({
         "create_count": "1",
         "update_count": "0",
         "expire_count": "0",
         "delete_count": "0",
         "extend_count": "0",
+    });
+    let storage: Value = json!({
+        "block_bytes": "42",
+        "total_bytes": "92",
+    });
+    let expected = json!({
+        "counts": counts,
+        "storage": storage,
     });
     assert_eq!(response, expected);
 
     // Test block 5
     let response: Value = test_server::send_get_request(&base, "/api/v1/block/5/stats").await;
-    let expected: Value = json!({
+    let counts: Value = json!({
         "create_count": "1",
         "update_count": "0",
         "expire_count": "0",
         "delete_count": "0",
         "extend_count": "0",
     });
+    let storage: Value = json!({
+        "block_bytes": "26",
+        "total_bytes": "118",
+    });
+    let expected = json!({
+        "counts": counts,
+        "storage": storage,
+    });
     assert_eq!(response, expected);
 
     // Test block 6
     let response: Value = test_server::send_get_request(&base, "/api/v1/block/6/stats").await;
-    let expected: Value = json!({
+    let counts: Value = json!({
         "create_count": "2",
         "update_count": "2",
         "expire_count": "0",
         "delete_count": "1",
         "extend_count": "1",
     });
+    let storage: Value = json!({
+        "block_bytes": "121",
+        "total_bytes": "121",
+    });
+    let expected = json!({
+        "counts": counts,
+        "storage": storage,
+    });
     assert_eq!(response, expected);
 
     // Test block 7
     let response: Value = test_server::send_get_request(&base, "/api/v1/block/7/stats").await;
-    let expected: Value = json!({
+    let counts: Value = json!({
         "create_count": "0",
         "update_count": "0",
         "expire_count": "1",
         "delete_count": "0",
         "extend_count": "0",
     });
+    let storage: Value = json!({
+        "block_bytes": "0",
+        "total_bytes": "88",
+    });
+    let expected = json!({
+        "counts": counts,
+        "storage": storage,
+    });
     assert_eq!(response, expected);
 
-    // Test block 8 - should return zeros for block with no operations
+    // Test block 8 - should return zero counters for a block with no operations
     let response: Value = test_server::send_get_request(&base, "/api/v1/block/8/stats").await;
-    let expected: Value = json!({
+    let counts: Value = json!({
         "create_count": "0",
         "update_count": "0",
         "expire_count": "0",
         "delete_count": "0",
         "extend_count": "0",
+    });
+    let storage: Value = json!({
+        "block_bytes": "0",
+        "total_bytes": "88",
+    });
+    let expected = json!({
+        "counts": counts,
+        "storage": storage,
     });
     assert_eq!(response, expected);
 }

--- a/golem-base-indexer/types/package.json
+++ b/golem-base-indexer/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@golembase/l3-indexer-types",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "TypeScript definitions for Golem Base Indexer microservice",
   "main": "./dist/golem-base-indexer-proto/proto/v1/golem-base-indexer.js",
   "types": "./dist/golem-base-indexer-proto/proto/v1/golem-base-indexer.d.ts",

--- a/golem-base-indexer/types/package.json
+++ b/golem-base-indexer/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@golembase/l3-indexer-types",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "TypeScript definitions for Golem Base Indexer microservice",
   "main": "./dist/golem-base-indexer-proto/proto/v1/golem-base-indexer.js",
   "types": "./dist/golem-base-indexer-proto/proto/v1/golem-base-indexer.d.ts",


### PR DESCRIPTION
This refactors API endpoint `/api/v1/block/{blockNumber}/stats` (see https://github.com/Golem-Base/blockscout-rs-neti/pull/42) and introduces storage metrics for a block.

Sample response:
```json
{
  "counts": {
    "create_count": "1",
    "update_count": "3",
    "expire_count": "5",
    "delete_count": "2",
    "extend_count": "3"
  },
  "storage": {
    "block_bytes": "828",
    "total_bytes": "16384"
  }
}
```

`block_bytes`: The sum of data bytes for all entities that were created, updated, or extended in this specific block. This represents the storage activity that occurred in this block.

`total_bytes`: The total storage bytes used on the entire chain up to and including this block. This represents the current state size - the sum of all active entities' data as they exist at this point in the blockchain history.