### PR TITLE
GBBE-202 - L3 Dashboard - Data statistics over time - Backend

### DIFF
--- a/golem-base-indexer/Cargo.lock
+++ b/golem-base-indexer/Cargo.lock
@@ -2910,6 +2910,7 @@ dependencies = [
  "pretty_assertions",
  "prometheus",
  "sea-orm",
+ "sea-query",
  "serde",
  "serde_with",
  "tokio",

--- a/golem-base-indexer/Cargo.toml
+++ b/golem-base-indexer/Cargo.toml
@@ -40,6 +40,7 @@ sea-orm-migration = { version = "1.1.13", features = [
   "runtime-tokio-rustls",
   "sqlx-postgres",
 ] }
+sea-query = "0.32"
 serde = "1"
 serde_json = "1.0.96"
 serde_with = "3.14.0"

--- a/golem-base-indexer/golem-base-indexer-logic/Cargo.toml
+++ b/golem-base-indexer/golem-base-indexer-logic/Cargo.toml
@@ -22,6 +22,7 @@ sea-orm = { workspace = true, features = [
   "macros",
   "postgres-array",
 ] }
+sea-query.workspace = true
 serde.workspace = true
 serde_with.workspace = true
 tokio.workspace = true

--- a/golem-base-indexer/golem-base-indexer-logic/src/repository/chart.rs
+++ b/golem-base-indexer/golem-base-indexer-logic/src/repository/chart.rs
@@ -293,7 +293,7 @@ fn generate_daily_points(
     let mut current_date = start_date;
     let mut last_known_value = initial_value;
 
-    while current_date <= end_date {
+    while current_date < end_date {
         let next_date = current_date + Duration::days(1);
 
         let value = match data_map.get(&current_date) {
@@ -393,7 +393,7 @@ fn generate_hourly_points(
     let mut current_time = start_time;
     let mut last_known_value = initial_value;
 
-    while current_time <= end_time {
+    while current_time < end_time {
         let next_hour = current_time + Duration::hours(1);
 
         let value = match data_map.get(&current_time) {

--- a/golem-base-indexer/golem-base-indexer-logic/src/repository/chart.rs
+++ b/golem-base-indexer/golem-base-indexer-logic/src/repository/chart.rs
@@ -1,0 +1,417 @@
+use anyhow::{anyhow, Context, Result};
+use chrono::{Duration, NaiveDate, NaiveDateTime, Utc};
+use sea_orm::{prelude::*, DbBackend, FromQueryResult, Statement};
+use sea_query::{ExprTrait, Iden, PostgresQueryBuilder, Query, SelectStatement};
+use std::collections::HashMap;
+use tracing::instrument;
+
+use crate::types::{ChartInfo, ChartPoint};
+
+#[derive(Debug)]
+pub enum ChartResolution {
+    Day,
+    Hour,
+}
+
+impl TryFrom<i32> for ChartResolution {
+    type Error = anyhow::Error;
+
+    fn try_from(value: i32) -> Result<Self> {
+        match value {
+            0 => Ok(ChartResolution::Day),
+            1 => Ok(ChartResolution::Hour),
+            _ => Err(anyhow!("Error converting chart resolution")),
+        }
+    }
+}
+
+#[derive(Iden)]
+pub enum GolemBaseTimeseries {
+    Table,
+    Timestamp,
+    ActiveDataBytes,
+}
+
+#[derive(Debug, FromQueryResult)]
+struct DbChartDataUsageDaily {
+    pub timestamp: NaiveDate,
+    pub active_data_bytes: i64,
+}
+
+#[derive(Debug, FromQueryResult)]
+struct DbChartDataUsageHourly {
+    pub timestamp: NaiveDateTime,
+    pub active_data_bytes: i64,
+}
+
+#[instrument(skip(db))]
+pub async fn chart_data_usage<T: ConnectionTrait>(
+    db: &T,
+    from: Option<String>,
+    to: Option<String>,
+    resolution: ChartResolution,
+) -> Result<(Vec<ChartPoint>, ChartInfo)> {
+    let chart = match resolution {
+        ChartResolution::Day => {
+            let (from_date, to_date) = parse_date_range(from, to)?;
+            let query = build_daily_data_usage_query(from_date, to_date);
+            let results = DbChartDataUsageDaily::find_by_statement(Statement::from_string(
+                DbBackend::Postgres,
+                query.to_string(PostgresQueryBuilder),
+            ))
+            .all(db)
+            .await
+            .context("Failed to get data usage timeseries")?;
+
+            let initial_value = if let Some(from_date) = from_date {
+                let lookback_query = build_daily_value_before_query(from_date);
+                let lookback_result =
+                    DbChartDataUsageDaily::find_by_statement(Statement::from_string(
+                        DbBackend::Postgres,
+                        lookback_query.to_string(PostgresQueryBuilder),
+                    ))
+                    .one(db)
+                    .await
+                    .context("Failed to get last known daily value")?;
+
+                lookback_result.map(|row| row.active_data_bytes)
+            } else {
+                None
+            };
+
+            generate_daily_points(results, from_date, to_date, initial_value)?
+        }
+        ChartResolution::Hour => {
+            let (from_datetime, to_datetime) = parse_datetime_range(from, to)?;
+            let query = build_hourly_data_usage_query(from_datetime, to_datetime);
+            let results = DbChartDataUsageHourly::find_by_statement(Statement::from_string(
+                DbBackend::Postgres,
+                query.to_string(PostgresQueryBuilder),
+            ))
+            .all(db)
+            .await
+            .context("Failed to get data usage timeseries")?;
+
+            let initial_value = if let Some(from_dt) = from_datetime {
+                let lookback_query = build_hourly_last_value_before_query(from_dt);
+                let lookback_result =
+                    DbChartDataUsageHourly::find_by_statement(Statement::from_string(
+                        DbBackend::Postgres,
+                        lookback_query.to_string(PostgresQueryBuilder),
+                    ))
+                    .one(db)
+                    .await
+                    .context("Failed to get last known hourly value")?;
+
+                lookback_result.map(|row| row.active_data_bytes)
+            } else {
+                None
+            };
+
+            generate_hourly_points(results, from_datetime, to_datetime, initial_value)?
+        }
+    };
+
+    let info = ChartInfo {
+        id: "golemBaseDataUsage".to_string(),
+        title: "Data over time".to_string(),
+        description: "Data storage over time".to_string(),
+    };
+
+    Ok((chart, info))
+}
+
+fn parse_date_range(
+    from: Option<String>,
+    to: Option<String>,
+) -> Result<(Option<NaiveDate>, Option<NaiveDate>)> {
+    let from_date = match from {
+        Some(date_str) => Some(
+            NaiveDate::parse_from_str(&date_str, "%Y-%m-%d")
+                .map_err(|e| anyhow!("Invalid from date format: {}", e))?,
+        ),
+        None => None,
+    };
+
+    let to_date = match to {
+        Some(date_str) => Some(
+            NaiveDate::parse_from_str(&date_str, "%Y-%m-%d")
+                .map_err(|e| anyhow!("Invalid to date format: {}", e))?,
+        ),
+        None => None,
+    };
+
+    if let (Some(from), Some(to)) = (from_date, to_date) {
+        if from > to {
+            return Err(anyhow!(
+                "From date ({}) cannot be later than to date ({})",
+                from.format("%Y-%m-%d"),
+                to.format("%Y-%m-%d")
+            ));
+        }
+    }
+
+    Ok((from_date, to_date))
+}
+
+fn parse_datetime_range(
+    from: Option<String>,
+    to: Option<String>,
+) -> Result<(Option<NaiveDateTime>, Option<NaiveDateTime>)> {
+    let current_datetime = Utc::now().naive_utc();
+
+    let from_datetime = match from {
+        Some(datetime_str) => Some(
+            NaiveDateTime::parse_from_str(&datetime_str, "%Y-%m-%d %H:%M")
+                .map_err(|e| anyhow!("Invalid from datetime format: {}", e))?,
+        ),
+        None => None,
+    };
+
+    let to_datetime = match to {
+        Some(datetime_str) => {
+            let parsed = NaiveDateTime::parse_from_str(&datetime_str, "%Y-%m-%d %H:%M")
+                .map_err(|e| anyhow!("Invalid to datetime format: {}", e))?;
+
+            Some(if parsed > current_datetime {
+                current_datetime
+            } else {
+                parsed
+            })
+        }
+        None => Some(Utc::now().naive_utc()),
+    };
+
+    if let (Some(from), Some(to)) = (from_datetime, to_datetime) {
+        if from > to {
+            return Err(anyhow!(
+                "From datetime ({}) cannot be later than to datetime ({})",
+                from.format("%Y-%m-%d %H:%M"),
+                to.format("%Y-%m-%d %H:%M")
+            ));
+        }
+    }
+
+    Ok((from_datetime, to_datetime))
+}
+
+fn build_daily_value_before_query(before_date: NaiveDate) -> SelectStatement {
+    Query::select()
+        .expr_as(
+            Expr::col(GolemBaseTimeseries::Timestamp).cast_as("date"),
+            "timestamp",
+        )
+        .expr_as(
+            Expr::max(Expr::col(GolemBaseTimeseries::ActiveDataBytes)),
+            GolemBaseTimeseries::ActiveDataBytes,
+        )
+        .from(GolemBaseTimeseries::Table)
+        .and_where(
+            Expr::col(GolemBaseTimeseries::Timestamp)
+                .cast_as("date")
+                .lt(before_date),
+        )
+        .group_by_col("timestamp")
+        .order_by("timestamp", sea_query::Order::Desc)
+        .limit(1)
+        .to_owned()
+}
+
+fn build_daily_data_usage_query(from: Option<NaiveDate>, to: Option<NaiveDate>) -> SelectStatement {
+    let mut query = Query::select()
+        .expr_as(
+            Expr::col(GolemBaseTimeseries::Timestamp).cast_as("date"),
+            "timestamp",
+        )
+        .expr_as(
+            Expr::max(Expr::col(GolemBaseTimeseries::ActiveDataBytes)),
+            GolemBaseTimeseries::ActiveDataBytes,
+        )
+        .from(GolemBaseTimeseries::Table)
+        .group_by_col("timestamp")
+        .order_by("timestamp", sea_query::Order::Asc)
+        .to_owned();
+
+    match (from, to) {
+        (Some(from_date), Some(to_date)) => {
+            query.and_where(
+                Expr::col(GolemBaseTimeseries::Timestamp)
+                    .cast_as("date")
+                    .between(from_date, to_date),
+            );
+        }
+        (Some(from_date), None) => {
+            query.and_where(
+                Expr::col(GolemBaseTimeseries::Timestamp)
+                    .cast_as("date")
+                    .gte(from_date),
+            );
+        }
+        (None, Some(to_date)) => {
+            query.and_where(
+                Expr::col(GolemBaseTimeseries::Timestamp)
+                    .cast_as("date")
+                    .lte(to_date),
+            );
+        }
+        (None, None) => {}
+    }
+
+    query
+}
+
+fn generate_daily_points(
+    db_results: Vec<DbChartDataUsageDaily>,
+    from_date: Option<NaiveDate>,
+    to_date: Option<NaiveDate>,
+    initial_value: Option<i64>,
+) -> Result<Vec<ChartPoint>> {
+    if db_results.is_empty() && initial_value.is_none() {
+        return Err(anyhow!("No data usage available"));
+    }
+
+    let data_map: HashMap<NaiveDate, i64> = db_results
+        .into_iter()
+        .map(|row| (row.timestamp, row.active_data_bytes))
+        .collect();
+
+    let start_date = match from_date {
+        Some(date) => date,
+        None => data_map
+            .keys()
+            .min()
+            .copied()
+            .unwrap_or_else(|| Utc::now().naive_utc().date()),
+    };
+
+    let end_date = match to_date {
+        Some(date) => date,
+        None => Utc::now().naive_utc().date(),
+    };
+
+    let mut points = Vec::new();
+    let mut current_date = start_date;
+    let mut last_known_value = initial_value;
+
+    while current_date <= end_date {
+        let next_date = current_date + Duration::days(1);
+
+        let value = match data_map.get(&current_date) {
+            Some(&actual_value) => {
+                last_known_value = Some(actual_value);
+                actual_value
+            }
+            None => last_known_value.unwrap_or(0),
+        };
+
+        points.push(ChartPoint {
+            date: current_date.format("%Y-%m-%d").to_string(),
+            date_to: next_date.format("%Y-%m-%d").to_string(),
+            value: value.to_string(),
+        });
+
+        current_date = next_date;
+    }
+
+    Ok(points)
+}
+
+fn build_hourly_last_value_before_query(before_datetime: NaiveDateTime) -> SelectStatement {
+    Query::select()
+        .columns([
+            GolemBaseTimeseries::Timestamp,
+            GolemBaseTimeseries::ActiveDataBytes,
+        ])
+        .from(GolemBaseTimeseries::Table)
+        .and_where(Expr::col(GolemBaseTimeseries::Timestamp).lt(before_datetime))
+        .order_by(GolemBaseTimeseries::Timestamp, sea_query::Order::Desc)
+        .limit(1)
+        .to_owned()
+}
+
+fn build_hourly_data_usage_query(
+    from: Option<NaiveDateTime>,
+    to: Option<NaiveDateTime>,
+) -> SelectStatement {
+    let mut query = Query::select()
+        .columns([
+            GolemBaseTimeseries::Timestamp,
+            GolemBaseTimeseries::ActiveDataBytes,
+        ])
+        .from(GolemBaseTimeseries::Table)
+        .order_by(GolemBaseTimeseries::Timestamp, sea_query::Order::Asc)
+        .to_owned();
+
+    match (from, to) {
+        (Some(from_datetime), Some(to_datetime)) => {
+            query.and_where(
+                Expr::col(GolemBaseTimeseries::Timestamp).between(from_datetime, to_datetime),
+            );
+        }
+        (Some(from_datetime), None) => {
+            query.and_where(Expr::col(GolemBaseTimeseries::Timestamp).gte(from_datetime));
+        }
+        (None, Some(to_datetime)) => {
+            query.and_where(Expr::col(GolemBaseTimeseries::Timestamp).lte(to_datetime));
+        }
+        (None, None) => {}
+    }
+
+    query
+}
+
+fn generate_hourly_points(
+    db_results: Vec<DbChartDataUsageHourly>,
+    from_datetime: Option<NaiveDateTime>,
+    to_datetime: Option<NaiveDateTime>,
+    initial_value: Option<i64>,
+) -> Result<Vec<ChartPoint>> {
+    if db_results.is_empty() && initial_value.is_none() {
+        return Err(anyhow!("No data usage available"));
+    }
+
+    let data_map: HashMap<NaiveDateTime, i64> = db_results
+        .into_iter()
+        .map(|row| (row.timestamp, row.active_data_bytes))
+        .collect();
+
+    let start_time = match from_datetime {
+        Some(dt) => dt,
+        None => data_map
+            .keys()
+            .min()
+            .copied()
+            .unwrap_or_else(|| Utc::now().naive_utc()),
+    };
+
+    let end_time = match to_datetime {
+        Some(dt) => dt,
+        None => Utc::now().naive_utc(),
+    };
+
+    let mut points = Vec::new();
+    let mut current_time = start_time;
+    let mut last_known_value = initial_value;
+
+    while current_time <= end_time {
+        let next_hour = current_time + Duration::hours(1);
+
+        let value = match data_map.get(&current_time) {
+            Some(&actual_value) => {
+                last_known_value = Some(actual_value);
+                actual_value
+            }
+            None => last_known_value.unwrap_or(0),
+        };
+
+        points.push(ChartPoint {
+            date: current_time.format("%Y-%m-%d %H:%M").to_string(),
+            date_to: next_hour.format("%Y-%m-%d %H:%M").to_string(),
+            value: value.to_string(),
+        });
+
+        current_time = next_hour;
+    }
+
+    Ok(points)
+}

--- a/golem-base-indexer/golem-base-indexer-logic/src/repository/mod.rs
+++ b/golem-base-indexer/golem-base-indexer-logic/src/repository/mod.rs
@@ -2,6 +2,7 @@ pub mod address;
 pub mod annotations;
 pub mod block;
 pub mod blockscout;
+pub mod chart;
 pub mod entities;
 pub mod logs;
 pub mod operations;

--- a/golem-base-indexer/golem-base-indexer-logic/src/types.rs
+++ b/golem-base-indexer/golem-base-indexer-logic/src/types.rs
@@ -341,3 +341,17 @@ pub struct EntityDataSize {
     pub entity_key: EntityKey,
     pub data_size: u64,
 }
+
+#[derive(Debug, Clone)]
+pub struct ChartPoint {
+    pub date: String,
+    pub date_to: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChartInfo {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+}

--- a/golem-base-indexer/golem-base-indexer-migration/src/lib.rs
+++ b/golem-base-indexer/golem-base-indexer-migration/src/lib.rs
@@ -10,6 +10,7 @@ mod m20250812_100925_create_entity_state_history_view;
 mod m20250818_181205_nullable_entity_owner;
 mod m20250827_115015_fix_tracking_expirations_in_view;
 mod m20250904_082310_add_golem_base_events_abi;
+mod m20250909_062255_create_golem_base_timeseries;
 
 pub struct Migrator;
 
@@ -26,6 +27,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20250818_181205_nullable_entity_owner::Migration),
             Box::new(m20250827_115015_fix_tracking_expirations_in_view::Migration),
             Box::new(m20250904_082310_add_golem_base_events_abi::Migration),
+            Box::new(m20250909_062255_create_golem_base_timeseries::Migration),
         ]
     }
 

--- a/golem-base-indexer/golem-base-indexer-migration/src/m20250909_062255_create_golem_base_timeseries.rs
+++ b/golem-base-indexer/golem-base-indexer-migration/src/m20250909_062255_create_golem_base_timeseries.rs
@@ -1,0 +1,49 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = r#"
+CREATE MATERIALIZED VIEW golem_base_timeseries AS
+WITH hourly_changes AS (
+    SELECT 
+        date_trunc('hour', block_timestamp) as timestamp,
+        SUM(
+            CASE 
+                WHEN operation = 'create' THEN 
+                    COALESCE(octet_length(data), 0)
+                WHEN operation = 'update' THEN 
+                    COALESCE(octet_length(data), 0) - COALESCE(octet_length(prev_data), 0)
+                WHEN operation = 'delete' THEN 
+                    -COALESCE(octet_length(data), 0)
+                ELSE 0  -- Ignores 'extend' and any other operations
+            END
+        ) as hourly_data_change
+    FROM golem_base_entity_history
+    WHERE operation IN ('create', 'update', 'delete')
+    GROUP BY date_trunc('hour', block_timestamp)
+)
+SELECT 
+    timestamp,
+    GREATEST(
+        SUM(hourly_data_change) OVER (ORDER BY timestamp ROWS UNBOUNDED PRECEDING), 
+        0
+    )::BIGINT as active_data_bytes
+FROM hourly_changes
+ORDER BY timestamp;
+"#;
+
+        crate::from_sql(manager, sql).await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = r#"
+DROP MATERIALIZED VIEW IF EXISTS golem_base_timeseries;
+        "#;
+
+        crate::from_sql(manager, sql).await
+    }
+}

--- a/golem-base-indexer/golem-base-indexer-proto/proto/v1/api_config_http.yaml
+++ b/golem-base-indexer/golem-base-indexer-proto/proto/v1/api_config_http.yaml
@@ -42,6 +42,9 @@ http:
     - selector: blockscout.golemBaseIndexer.v1.GolemBaseIndexerService.ListLargestEntities
       get: /api/v1/leaderboard/largest-entities
 
+    - selector: blockscout.golemBaseIndexer.v1.GolemBaseIndexerService.ChartDataUsage
+      get: /api/v1/chart/data-usage
+
     #################### Health ####################
 
     - selector: blockscout.golemBaseIndexer.v1.Health.Check

--- a/golem-base-indexer/golem-base-indexer-proto/proto/v1/golem-base-indexer.proto
+++ b/golem-base-indexer/golem-base-indexer-proto/proto/v1/golem-base-indexer.proto
@@ -22,6 +22,8 @@ service GolemBaseIndexerService {
   rpc ListEntitiesByBtl(ListEntitiesByBtlRequest) returns (ListEntitiesByBtlResponse);
   rpc ListAddressByEntitiesOwned(ListAddressByEntitiesOwnedRequest) returns (ListAddressByEntitiesOwnedResponse);
   rpc ListLargestEntities(ListLargestEntitiesRequest) returns (ListLargestEntitiesResponse);
+  
+  rpc ChartDataUsage(ChartDataUsageRequest) returns (ChartDataUsageResponse);
 }
 
 message AddressStatsRequest {
@@ -315,4 +317,32 @@ message ListLargestEntitiesResponse {
 message EntityDataSize {
   string entity_key = 1;
   uint64 data_size = 2;
+}
+
+enum ChartResolution {
+  DAY = 0;
+  HOUR = 1;
+}
+
+message ChartInfo {
+  string id = 1;
+  string title = 2;
+  string description = 3;
+}
+
+message ChartPoint {
+  string date = 1;
+  string date_to = 2;
+  string value = 3;
+}
+
+message ChartDataUsageRequest {
+  optional string from = 1;
+  optional string to = 2;
+  ChartResolution resolution = 3;
+}
+
+message ChartDataUsageResponse {
+  repeated ChartPoint chart = 1;
+  ChartInfo info = 2;
 }

--- a/golem-base-indexer/golem-base-indexer-proto/src/lib.rs
+++ b/golem-base-indexer/golem-base-indexer-proto/src/lib.rs
@@ -4,9 +4,9 @@ use const_hex::traits::ToHexExt;
 
 use anyhow::{anyhow, Result};
 use golem_base_indexer_logic::types::{
-    AddressByEntitiesOwned, BiggestSpenders, BlockEntitiesCount, BlockStorageUsage, EntitiesFilter,
-    Entity, EntityDataSize, EntityHistoryEntry, EntityHistoryFilter, EntityStatus,
-    EntityWithExpTimestamp, FullEntity, ListEntitiesFilter, ListOperationsFilter,
+    AddressByEntitiesOwned, BiggestSpenders, BlockEntitiesCount, BlockStorageUsage, ChartInfo,
+    ChartPoint, EntitiesFilter, Entity, EntityDataSize, EntityHistoryEntry, EntityHistoryFilter,
+    EntityStatus, EntityWithExpTimestamp, FullEntity, ListEntitiesFilter, ListOperationsFilter,
     NumericAnnotation, NumericAnnotationWithRelations, OperationData, OperationFilter,
     OperationView, OperationsCount, OperationsFilter, PaginationMetadata, PaginationParams,
     StringAnnotation, StringAnnotationWithRelations,
@@ -551,6 +551,26 @@ impl From<EntityDataSize> for v1::EntityDataSize {
         Self {
             entity_key: v.entity_key.to_string(),
             data_size: v.data_size,
+        }
+    }
+}
+
+impl From<ChartInfo> for v1::ChartInfo {
+    fn from(v: ChartInfo) -> Self {
+        Self {
+            id: v.id,
+            title: v.title,
+            description: v.description,
+        }
+    }
+}
+
+impl From<ChartPoint> for v1::ChartPoint {
+    fn from(v: ChartPoint) -> Self {
+        Self {
+            date: v.date,
+            date_to: v.date_to,
+            value: v.value,
         }
     }
 }

--- a/golem-base-indexer/golem-base-indexer-proto/swagger/v1/golem-base-indexer.swagger.yaml
+++ b/golem-base-indexer/golem-base-indexer-proto/swagger/v1/golem-base-indexer.swagger.yaml
@@ -48,6 +48,37 @@ paths:
           type: string
       tags:
         - GolemBaseIndexerService
+  /api/v1/chart/data-usage:
+    get:
+      operationId: GolemBaseIndexerService_ChartDataUsage
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ChartDataUsageResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: from
+          in: query
+          required: false
+          type: string
+        - name: to
+          in: query
+          required: false
+          type: string
+        - name: resolution
+          in: query
+          required: false
+          type: string
+          enum:
+            - DAY
+            - HOUR
+          default: DAY
+      tags:
+        - GolemBaseIndexerService
   /api/v1/entities:
     get:
       operationId: GolemBaseIndexerService_ListEntities
@@ -515,6 +546,40 @@ definitions:
       total_bytes:
         type: string
         format: uint64
+  v1ChartDataUsageResponse:
+    type: object
+    properties:
+      chart:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1ChartPoint'
+      info:
+        $ref: '#/definitions/v1ChartInfo'
+  v1ChartInfo:
+    type: object
+    properties:
+      id:
+        type: string
+      title:
+        type: string
+      description:
+        type: string
+  v1ChartPoint:
+    type: object
+    properties:
+      date:
+        type: string
+      date_to:
+        type: string
+      value:
+        type: string
+  v1ChartResolution:
+    type: string
+    enum:
+      - DAY
+      - HOUR
+    default: DAY
   v1CountEntitiesResponse:
     type: object
     properties:

--- a/golem-base-indexer/golem-base-indexer-server/src/services/golem_base_indexer.rs
+++ b/golem-base-indexer/golem-base-indexer-server/src/services/golem_base_indexer.rs
@@ -364,4 +364,27 @@ impl GolemBaseIndexer for GolemBaseIndexerService {
             pagination: Some(pagination.into()),
         }))
     }
+
+    async fn chart_data_usage(
+        &self,
+        request: Request<ChartDataUsageRequest>,
+    ) -> Result<Response<ChartDataUsageResponse>, Status> {
+        let inner = request.into_inner();
+        let resolution = inner
+            .resolution
+            .try_into()
+            .map_err(|_| Status::invalid_argument("Unsupported chart resolution"))?;
+        let (points, info) =
+            repository::chart::chart_data_usage(&*self.db, inner.from, inner.to, resolution)
+                .await
+                .map_err(|err| {
+                    tracing::error!(?err, "failed to query data usage timeseries");
+                    Status::internal("failed to query data usage timeseries")
+                })?;
+
+        Ok(Response::new(ChartDataUsageResponse {
+            chart: points.into_iter().map(Into::into).collect(),
+            info: Some(info.into()),
+        }))
+    }
 }

--- a/golem-base-indexer/golem-base-indexer-server/tests/chart_data_usage.rs
+++ b/golem-base-indexer/golem-base-indexer-server/tests/chart_data_usage.rs
@@ -1,0 +1,98 @@
+mod helpers;
+
+use blockscout_service_launcher::test_server;
+use golem_base_indexer_logic::Indexer;
+use sea_orm::{ConnectionTrait, DbBackend, Statement};
+use serde_json::{json, Value};
+
+#[tokio::test]
+#[ignore = "Needs database to run"]
+async fn hourly_data_usage_should_work() {
+    // Setup
+    let db = helpers::init_db("test", "hourly_data_usage_should_work").await;
+    let client = db.client();
+    let base = helpers::init_golem_base_indexer_server(db, |x| x).await;
+    helpers::load_data(&*client, include_str!("fixtures/sample_data.sql")).await;
+
+    Indexer::new(client.clone(), Default::default())
+        .tick()
+        .await
+        .unwrap();
+
+    client
+        .execute(Statement::from_string(
+            DbBackend::Postgres,
+            "REFRESH MATERIALIZED VIEW golem_base_timeseries",
+        ))
+        .await
+        .expect("Refresh of MATERIALIZED VIEW failed!");
+
+    let response: Value = test_server::send_get_request(
+        &base,
+        "/api/v1/chart/data-usage?resolution=HOUR&from=2025-07-22%2011:00&to=2025-07-22%2012:00",
+    )
+    .await;
+
+    let expected: Value = json!({
+        "info": {
+            "id": "golemBaseDataUsage",
+            "title": "Data over time",
+            "description": "Data storage over time",
+        },
+        "chart": [
+            {
+                "date": "2025-07-22 11:00",
+                "date_to": "2025-07-22 12:00",
+                "value": "146",
+            }
+        ]
+    });
+
+    assert_eq!(response, expected);
+}
+
+#[tokio::test]
+#[ignore = "Needs database to run"]
+async fn daily_data_usage_should_work() {
+    // Setup
+    let db = helpers::init_db("test", "daily_data_usage_should_work").await;
+    let client = db.client();
+    let base = helpers::init_golem_base_indexer_server(db, |x| x).await;
+    helpers::load_data(&*client, include_str!("fixtures/sample_data.sql")).await;
+
+    Indexer::new(client.clone(), Default::default())
+        .tick()
+        .await
+        .unwrap();
+
+    client
+        .execute(Statement::from_string(
+            DbBackend::Postgres,
+            "REFRESH MATERIALIZED VIEW golem_base_timeseries",
+        ))
+        .await
+        .expect("Refresh of MATERIALIZED VIEW failed!");
+
+    let response: Value = test_server::send_get_request(
+        &base,
+        "/api/v1/chart/data-usage?resolution=DAY&from=2025-07-22&to=2025-07-22",
+    )
+    .await;
+
+    let expected: Value = json!({
+        "info": {
+            "id": "golemBaseDataUsage",
+            "title": "Data over time",
+            "description": "Data storage over time",
+        },
+        "chart": [
+            {
+                "date": "2025-07-22",
+                "date_to": "2025-07-23",
+                "value": "88",
+            }
+        ]
+    });
+
+    assert_eq!(response, expected);
+}

--- a/golem-base-indexer/golem-base-indexer-server/tests/chart_data_usage.rs
+++ b/golem-base-indexer/golem-base-indexer-server/tests/chart_data_usage.rs
@@ -7,9 +7,9 @@ use serde_json::{json, Value};
 
 #[tokio::test]
 #[ignore = "Needs database to run"]
-async fn hourly_data_usage_should_work() {
+async fn chart_data_usage_should_work() {
     // Setup
-    let db = helpers::init_db("test", "hourly_data_usage_should_work").await;
+    let db = helpers::init_db("test", "chart_data_usage_should_work").await;
     let client = db.client();
     let base = helpers::init_golem_base_indexer_server(db, |x| x).await;
     helpers::load_data(&*client, include_str!("fixtures/sample_data.sql")).await;
@@ -27,6 +27,7 @@ async fn hourly_data_usage_should_work() {
         .await
         .expect("Refresh of MATERIALIZED VIEW failed!");
 
+    // Hourly
     let response: Value = test_server::send_get_request(
         &base,
         "/api/v1/chart/data-usage?resolution=HOUR&from=2025-07-22%2011:00&to=2025-07-22%2012:00",
@@ -49,33 +50,11 @@ async fn hourly_data_usage_should_work() {
     });
 
     assert_eq!(response, expected);
-}
 
-#[tokio::test]
-#[ignore = "Needs database to run"]
-async fn daily_data_usage_should_work() {
-    // Setup
-    let db = helpers::init_db("test", "daily_data_usage_should_work").await;
-    let client = db.client();
-    let base = helpers::init_golem_base_indexer_server(db, |x| x).await;
-    helpers::load_data(&*client, include_str!("fixtures/sample_data.sql")).await;
-
-    Indexer::new(client.clone(), Default::default())
-        .tick()
-        .await
-        .unwrap();
-
-    client
-        .execute(Statement::from_string(
-            DbBackend::Postgres,
-            "REFRESH MATERIALIZED VIEW golem_base_timeseries",
-        ))
-        .await
-        .expect("Refresh of MATERIALIZED VIEW failed!");
-
+    // Daily
     let response: Value = test_server::send_get_request(
         &base,
-        "/api/v1/chart/data-usage?resolution=DAY&from=2025-07-22&to=2025-07-22",
+        "/api/v1/chart/data-usage?resolution=DAY&from=2025-07-22&to=2025-07-23",
     )
     .await;
 
@@ -89,7 +68,7 @@ async fn daily_data_usage_should_work() {
             {
                 "date": "2025-07-22",
                 "date_to": "2025-07-23",
-                "value": "88",
+                "value": "146",
             }
         ]
     });

--- a/golem-base-indexer/types/package.json
+++ b/golem-base-indexer/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@golembase/l3-indexer-types",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "TypeScript definitions for Golem Base Indexer microservice",
   "main": "./dist/golem-base-indexer-proto/proto/v1/golem-base-indexer.js",
   "types": "./dist/golem-base-indexer-proto/proto/v1/golem-base-indexer.d.ts",


### PR DESCRIPTION
## Changes Description 

This adds a new API endpoint `/api/v1/chart/data-usage` that provides data for rendering a "Data over time" line chart.
Request parameters and response format are designed to be compatible with `stats` microservice where applicable.

Request parameters:

- **resolution**: `DAY` or `HOUR`
- **from**: Start time (inclusive)
  - For `DAY`: date format `"2025-09-15"`  
  - For `HOUR`: datetime format `"2025-09-15 08:00"`
- **to**: End time (exclusive) - same format as `from`

Sample response:
```json
{
  "chart": [
    {
      "date": "2025-09-12",
      "date_to": "2025-09-13",
      "value": "9817"
    },
    {
      "date": "2025-09-13",
      "date_to": "2025-09-14",
      "value": "27620"
    },
    {
      "date": "2025-09-14",
      "date_to": "2025-09-15",
      "value": "98374"
    }
  ],
  "info": {
    "id": "golemBaseDataUsage",
    "title": "Data over time",
    "description": "Data storage over time"
  }
}
```

**TODO**: decide on refresh strategy of `golem_base_timeseries` materialized view (`pg_cron` or in-code refresh?)

## Checklist
- [X] I have tested these changes locally.
- [X] I added tests to cover any new functionality.
- [X] I have updated types package version if there are any API changes.
